### PR TITLE
Add items count to books

### DIFF
--- a/API_DOC.md
+++ b/API_DOC.md
@@ -67,7 +67,9 @@
                 "publisher": "\"Издательский дом \"\"Питер\"\"\"",
                 "description": "В этой книге вы найдете ключевые принципы, алгоритмы и компромиссы...",
                 "cover_image": "http://books.google.com/books/content?id=ehpKDwAAQBAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=1\u0026edge=curl\u0026source=gbs_api",
-                "page_count":640
+                "page_count": 640,
+                "total_items_count": 2,
+                "available_items_count": 1
             },
             ...
         ]
@@ -120,7 +122,8 @@
             isbn_10: "5001006139",
             isbn_13: "9785001006138",
             cover_image: "http://books.google.com/books/content?id=9Fd2DgAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
-            page_count: 272
+            page_count: 272,
+            total_items_count: 1
         }
     }
     
@@ -160,6 +163,13 @@
             "title": "Первые 90 дней",
             "subtitle": "Стратегии успеха для новых лидеров всех уровней",
             "authors": "Майкл Уоткинс",
-            ...
+            "publisher": "Манн, Иванов и Фербер",
+            "description": "Как показывает практика, самый рискованный период для любого менеджера на новой работе...",
+            "isbn_10": "5001006139",
+            "isbn_13": "9785001006138",
+            "cover_image": "http://books.google.com/books/content?id=9Fd2DgAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
+            "page_count": 272,
+            "total_items_count": 2,
+            "available_items_count": 1
         }
     }

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::BooksController < Api::V1::BaseController
 
   def create
     book = Book.new(book_params)
+    book.available_items_count = book_params[:total_items_count]
     if book.save
       render json: book
     else
@@ -26,7 +27,8 @@ class Api::V1::BooksController < Api::V1::BaseController
   private
 
   def book_params
-    permitted_params = %i[title subtitle authors publisher description cover_image page_count isbn_10 isbn_13]
+    permitted_params = %i[title subtitle authors publisher description cover_image page_count isbn_10 isbn_13
+                          total_items_count]
     params.require(:book).permit(permitted_params)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,3 +1,5 @@
 class Book < ApplicationRecord
   validates :title, :authors, presence: true
+  validates :total_items_count, numericality: { only_integer: true, allow_nil: true }
+  validates :available_items_count, numericality: { only_integer: true, allow_nil: true }
 end

--- a/app/serializers/api/v1/book_serializer.rb
+++ b/app/serializers/api/v1/book_serializer.rb
@@ -1,3 +1,4 @@
 class Api::V1::BookSerializer < ActiveModel::Serializer
-  attributes :id, :title, :subtitle, :authors, :publisher, :description, :cover_image, :page_count
+  attributes :id, :title, :subtitle, :authors, :publisher, :description, :cover_image, :page_count,
+             :total_items_count, :available_items_count
 end

--- a/db/migrate/20191229070647_add_items_count_to_books.rb
+++ b/db/migrate/20191229070647_add_items_count_to_books.rb
@@ -1,0 +1,6 @@
+class AddItemsCountToBooks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :books, :total_items_count, :integer, default: 1, null: false
+    add_column :books, :available_items_count, :integer, default: 1, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_27_054612) do
+ActiveRecord::Schema.define(version: 2019_12_29_070647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,8 @@ ActiveRecord::Schema.define(version: 2019_12_27_054612) do
     t.integer "page_count"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "total_items_count", default: 1, null: false
+    t.integer "available_items_count", default: 1, null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Добавила для книг 2 поля: 
`total_items_count` – кол-во экземпляров в фонде библиотеки
`available_items_count` – кол-во доступных (не занятых) экземпляров